### PR TITLE
with_process_cleanup now prints a report

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -2,6 +2,7 @@
 
 S3method(format,ps_handle)
 S3method(print,ps_handle)
+S3method(print,with_process_cleanup)
 export(ps)
 export(ps_boot_time)
 export(ps_children)

--- a/man/ps_kill_tree.Rd
+++ b/man/ps_kill_tree.Rd
@@ -46,6 +46,12 @@ variable, and kills them (or sends them the specified signal on Unix).
 \code{with_process_cleanup()} evaluates an R expression, and cleans up all
 external processes that were started by the R process while evaluating
 the expression. This includes child processes of child processes, etc.,
-recursively.
+recursively. It returns a list with entries: \code{result} is the result of
+the expression, \code{visible} is TRUE if the expression should be printed
+to the screen, and \code{process_cleanup} is a named integer vector of the
+cleaned pids, names are the process names.
+
+If \code{expr} throws an error, then so does \code{with_process_cleanup()}, the
+same error. Nevertheless processes are still cleaned up.
 }
 \keyword{internal}


### PR DESCRIPTION
Looks like this:
```r
  p <- NULL
  with_process_cleanup({
    p <- lapply(1:3, function(x) {
      processx::process$new(px(), c("sleep", "10"))
    })
    expect_equal(length(p), 3)
    lapply(p, function(pp) expect_true(pp$is_alive()))
  })
```

```
[[1]]
[1] TRUE

[[2]]
[1] TRUE

[[3]]
[1] TRUE

!! Cleaned up the following processes:
  px   px   px
8938 8939 8940
```