### PR TITLE
Improve checks for process start time

### DIFF
--- a/src/api-linux.c
+++ b/src/api-linux.c
@@ -261,8 +261,12 @@ int psll_linux_get_boot_time() {
   return 0;
 }
 
-int psll_linux_get_clock_ticks() {
+int psll_linux_get_clock_ticks(void) {
   psll_linux_clock_ticks = sysconf(_SC_CLK_TCK);
+  if (psll_linux_clock_ticks == -1) {
+    ps__set_error_from_errno();
+    return -1;
+  }
   return 0;
 }
 
@@ -278,7 +282,9 @@ int psll_linux_ctime(long pid, double *ctime) {
 
   if (!psll_linux_clock_ticks) {
     ret = psll_linux_get_clock_ticks();
-    if (ret) return ret;
+    if (ret) {
+      ps__throw_error();
+    }
   }
 
   *ctime = psll_linux_boot_time + stat.starttime / psll_linux_clock_ticks;


### PR DESCRIPTION
Firstly, invert the sense of `psll_linux_clock_ticks` so that the reciprocal is saved instead. It is generally said that division is slower than multiplication, and there are many more multiplications now vs the one reciprocal. I did not actually benchmark it though; the main benefit is that the period provides a convenient epsilon to use for the second change.

The second change is turning strict double equality checks into epsilon comparisons. Even though printing out the two values shows them to be the same, the `PS__CHECK_STAT` check still fails (I think because of the 80-bit registers on 32-bit systems.) This change would fix #41.

I also threw in a little bit of extra error handling for `sysconf` results.