### PR TITLE
Get physical CPU count from lscpu if available.

### DIFF
--- a/R/linux.R
+++ b/R/linux.R
@@ -141,9 +141,11 @@ psl__decode_address <- function(addr, family) {
 }
 
 psl__cpu_count_from_lscpu <- function() {
-  lines <- system("lscpu -p=core", intern = TRUE)
-  cores <- unique(lines[!str_starts_with(lines, "#")])
-  length(cores)
+  tryCatch({
+    lines <- system("lscpu -p=core", intern = TRUE)
+    cores <- unique(lines[!str_starts_with(lines, "#")])
+    length(cores)
+  }, error = function(e) psl__cpu_count_from_cpuinfo())
 }
 
 psl__cpu_count_from_cpuinfo <- function() {

--- a/R/linux.R
+++ b/R/linux.R
@@ -142,14 +142,7 @@ psl__decode_address <- function(addr, family) {
 
 psl__cpu_count_from_lscpu <- function() {
   lines <- system("lscpu -p=core", intern = TRUE)
-  cores = list()
-
-  for (l in lines) {
-    if (!str_starts_with(l, "#")) {
-      cores[str_strip(l)] <- 1
-    }
-  }
-
+  cores <- unique(lines[!str_starts_with(lines, "#")])
   length(cores)
 }
 

--- a/R/linux.R
+++ b/R/linux.R
@@ -140,7 +140,20 @@ psl__decode_address <- function(addr, family) {
   }
 }
 
-ps_cpu_count_physical_linux <- function() {
+psl__cpu_count_from_lscpu <- function() {
+  lines <- system("lscpu -p=core", intern = TRUE)
+  cores = list()
+
+  for (l in lines) {
+    if (!str_starts_with(l, "#")) {
+      cores[str_strip(l)] <- 1
+    }
+  }
+
+  length(cores)
+}
+
+psl__cpu_count_from_cpuinfo <- function() {
   lines <- readLines("/proc/cpuinfo")
   mapping = list()
   current = list()
@@ -164,4 +177,12 @@ ps_cpu_count_physical_linux <- function() {
   }
 
   sum(as.integer(unlist(mapping)))
+}
+
+ps_cpu_count_physical_linux <- function() {
+  if (Sys.which("lscpu") != "") {
+    psl__cpu_count_from_lscpu()
+  } else {
+    psl__cpu_count_from_cpuinfo()
+  }
 }


### PR DESCRIPTION
This appears to work for all systems I mentioned earlier: https://koji.fedoraproject.org/koji/taskinfo?taskID=33591831

Fixes #60.