### PR TITLE
New windows version query in configure

### DIFF
--- a/configure
+++ b/configure
@@ -75,9 +75,7 @@ MACROS="$MACROS PS__VERSION"
 PS__VERSION=546
 
 if [ -n "$WINDOWS" ]; then
-    RAWVER=`$RBIN --vanilla --slave -e "system('cmd /c ver')"`
-    VER=`echo $RAWVER | grep "\[[Vv]ersion.*\]" | sed "s/^.*\[[Vv]ersion\s*//" |
-                      sed "s/\].*$//"`
+    VER=`$RBIN --vanilla --slave -f inst/tools/winver.R`
     MAJOR=`echo $VER | cut -f1 -d.`
     MINOR=`echo $VER | cut -f2 -d.`
     WINVER=`$RBIN --vanilla --slave -e "cat(sprintf('0x0%s', $MAJOR*100 + $MINOR))"`

--- a/inst/tools/winver.R
+++ b/inst/tools/winver.R
@@ -1,0 +1,30 @@
+
+winver_ver <- function(v = NULL) {
+  if (is.null(v)) v <- system("cmd /c ver", intern = TRUE)
+  v2 <- grep("\\[.*\\s.*\\]", v, value = TRUE)[1]
+  v3 <- sub("^.*\\[[^ ]+\\s+", "", v2)
+  v4 <- sub("\\]$", "", v3)
+  if (is.na(v4)) stop("Failed to parse windows version")
+  v4
+}
+
+winver_wmic <- function(v = NULL) {
+  cmd <- "wmic os get Version /value"
+  if (is.null(v)) v <- system(cmd, intern = TRUE)
+  v2 <- grep("=", v, value = TRUE)
+  v3 <- strsplit(v2, "=", fixed = TRUE)[[1]][2]
+  v4 <- sub("\\s*$", "", sub("^\\s*", "", v3))
+  if (is.na(v4)) stop("Failed to parse windows version")
+  v4
+}
+
+winver <- function() {
+  ## First we try with `wmic`
+  v <- if (Sys.which("wmic") != "") {
+    tryCatch(winver_wmic(), error = function(e) NULL)
+  }
+  ## Otherwise `ver`
+  if (is.null(v)) winver_ver() else v
+}
+
+if (is.null(sys.calls())) cat(winver())

--- a/tests/testthat/test-winver.R
+++ b/tests/testthat/test-winver.R
@@ -1,0 +1,27 @@
+
+context("winver")
+
+test_that("winver_ver", {
+  cases <- list(
+    list(c("", "Microsoft Windows [Version 6.3.9600]"), "6.3.9600"),
+    list("Microsoft Windows [version 6.1.7601]", "6.1.7601"),
+    list("Microsoft Windows [vers\u00e3o 10.0.18362.207]", "10.0.18362.207"))
+
+  source(system.file("tools", "winver.R", package = "ps"), local = TRUE)
+  
+  for (x in cases) expect_identical(winver_ver(x[[1]]), x[[2]])
+})
+
+test_that("winver_wmic", {
+  cases <- list(
+    list(c("\r", "\r", "Version=6.3.9600\r", "\r", "\r", "\r"),
+         "6.3.9600"),
+    list(c("\r", "\r", "version=6.3.9600\r", "\r", "\r", "\r"),
+         "6.3.9600"),
+    list(c("\r", "\r", "vers\u00e3o=6.3.9600\r", "\r", "\r", "\r"),
+         "6.3.9600"))    
+
+  source(system.file("tools", "winver.R", package = "ps"), local = TRUE)
+  
+  for (x in cases) expect_identical(winver_wmic(x[[1]]), x[[2]])
+})


### PR DESCRIPTION
Because the old one fails on non-English systems.

The code is now in an R file, so that we can test it better. 

It tries to use `wmic` first. `wmic` should produce the same output,
irrespectively of the language. It `wmic` fails, e.g. because it is
not available, then we fall back to `ver`, but use a much more forgiving
regex. As long as the version number is the last word within square
brackets, this should work.

Closes #69