### PR TITLE
Fix Windows memory percentage scaling

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,6 +31,6 @@ Suggests:
 Biarch: true
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.0
+RoxygenNote: 7.2.1
 Config/testthat/edition: 3
 Config/Needs/website: tidyverse/tidytemplate

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 
 # ps development version
 
+* `ps_system_memory()$percent` now returns a number scaled between 0 and 100 on Windows, rather than between 0 and 1 (#131, @francisbarton).
+
 # ps 1.7.1
 
 * ps now returns data frames instead of tibbles. While data frames and
@@ -57,7 +59,7 @@
 
 * New `ps_tty_size()` function to query the size of the terminal.
 
-* Fixed an issue in `CLeanupReporter()` that triggered random failures
+* Fixed an issue in `CleanupReporter()` that triggered random failures
   on macOS.
 
 # ps 1.3.4

--- a/R/memory.R
+++ b/R/memory.R
@@ -50,7 +50,7 @@ ps_system_memory <- function() {
     l <- .Call(ps__system_memory)[c("total", "avail")]
     l$free <- l$avail
     l$used <- l$total - l$avail
-    l$percent <- (l$total - l$avail) / l$total
+    l$percent <- (l$total - l$avail) * 100 / l$total
     l[c("total", "avail", "percent", "used", "free")]
 
   } else {
@@ -137,7 +137,7 @@ ps_system_swap <- function() {
     total <- l[[3]]
     free <- l[[4]]
     used <- total - free
-    percent = used / total
+    percent <- used / total
     list(total = total, used = used, free = free,
          percent = percent, sin = NA_real_, sout = NA_real_)
 

--- a/R/testthat-reporter.R
+++ b/R/testthat-reporter.R
@@ -48,7 +48,7 @@ globalVariables("private")
 #'
 #' @param reporter A testthat reporter to wrap into a new `CleanupReporter`
 #'   class.
-#' @return New reporter class  that behaves exactly like `reporter`,
+#' @return New reporter class that behaves exactly like `reporter`,
 #'   but it checks for, and optionally cleans up child processes, at the
 #'   specified granularity.
 #'

--- a/man/CleanupReporter.Rd
+++ b/man/CleanupReporter.Rd
@@ -11,7 +11,7 @@ CleanupReporter(reporter = testthat::ProgressReporter)
 class.}
 }
 \value{
-New reporter class  that behaves exactly like \code{reporter},
+New reporter class that behaves exactly like \code{reporter},
 but it checks for, and optionally cleans up child processes, at the
 specified granularity.
 }

--- a/tests/testthat/test-windows.R
+++ b/tests/testthat/test-windows.R
@@ -27,3 +27,10 @@ test_that("terminal", {
 ## TODO: username
 ## TODO: cpu_times
 ## TODO: memory_info
+
+test_that("total and available mem", {
+  l <- .Call(ps__system_memory)[c("total", "avail")]
+  expect_that(is.numeric(l$total))
+  expect_that(is.numeric(l$avail))
+  expect_lte(l$avail, l$total)
+})


### PR DESCRIPTION
Simple fix for memory percentage scaling on Windows. Possibly a breaking change though.
Added a simple test but couldn't think of anything else to test for `l$percent` itself.
Should resolve #131.