### PR TITLE
api-macos.c: fix missing stdbool

### DIFF
--- a/src/api-macos.c
+++ b/src/api-macos.c
@@ -21,6 +21,8 @@
 #include "ps-internal.h"
 #include "arch/macos/process_info.h"
 
+#include <stdbool.h>
+
 #define PS__TV2DOUBLE(t) ((t).tv_sec + (t).tv_usec / 1000000.0)
 
 #define PS__CHECK_KINFO(kp, handle)				      \


### PR DESCRIPTION
Adds a missing header.