### PR TITLE
api-macos.c: restore PPC arch support

### DIFF
--- a/src/api-macos.c
+++ b/src/api-macos.c
@@ -839,6 +839,14 @@ static bool ps_in_shared_region(mach_vm_address_t addr, cpu_type_t type) {
     base = SHARED_REGION_BASE_X86_64;
     size = SHARED_REGION_SIZE_X86_64;
     break;
+  case CPU_TYPE_POWERPC:
+    base = SHARED_REGION_BASE_PPC;
+    size = SHARED_REGION_SIZE_PPC;
+    break;
+  case CPU_TYPE_POWERPC64:
+    base = SHARED_REGION_BASE_PPC64;
+    size = SHARED_REGION_SIZE_PPC64;
+    break;
   default:
     return false;
   }


### PR DESCRIPTION
Usage of POWERPC* vs PPC* is intended.
Example of CPU_TYPE* usage: https://opensource.apple.com/source/cctools/cctools-758/libstuff/arch.c
`SHARED_REGION_BASE_PPC` and `SHARED_REGION_SIZE_PPC` are defined in `usr/include/mach/shared_region.h`:
```
#ifndef _MACH_SHARED_REGION_H_
#define _MACH_SHARED_REGION_H_

#include <sys/cdefs.h>
#include <mach/vm_prot.h>
#include <mach/vm_types.h>
#include <mach/mach_types.h>

#define SHARED_REGION_BASE_I386			0x90000000ULL
#define SHARED_REGION_SIZE_I386			0x20000000ULL
#define SHARED_REGION_NESTING_BASE_I386		0x90000000ULL
#define SHARED_REGION_NESTING_SIZE_I386		0x20000000ULL
#define SHARED_REGION_NESTING_MIN_I386		0x00200000ULL
#define SHARED_REGION_NESTING_MAX_I386		0xFFE00000ULL

#define SHARED_REGION_BASE_X86_64		0x00007FFF70000000ULL
#define SHARED_REGION_SIZE_X86_64		0x000000008FE00000ULL
#define SHARED_REGION_NESTING_BASE_X86_64	0x00007FFF80000000ULL
#define SHARED_REGION_NESTING_SIZE_X86_64	0x0000000040000000ULL
#define SHARED_REGION_NESTING_MIN_X86_64	0x0000000000200000ULL
#define SHARED_REGION_NESTING_MAX_X86_64	0xFFFFFFFFFFE00000ULL

#define SHARED_REGION_BASE_PPC			0x90000000ULL
#define SHARED_REGION_SIZE_PPC			0x20000000ULL
#define SHARED_REGION_NESTING_BASE_PPC		0x90000000ULL
#define SHARED_REGION_NESTING_SIZE_PPC		0x10000000ULL
#define SHARED_REGION_NESTING_MIN_PPC		0x10000000ULL
#define SHARED_REGION_NESTING_MAX_PPC		0x10000000ULL

#define SHARED_REGION_BASE_PPC64		0x00007FFF60000000ULL
#define SHARED_REGION_SIZE_PPC64		0x00000000A0000000ULL
#define SHARED_REGION_NESTING_BASE_PPC64	0x00007FFF60000000ULL
#define SHARED_REGION_NESTING_SIZE_PPC64	0x00000000A0000000ULL
#define SHARED_REGION_NESTING_MIN_PPC64		0x0000000010000000ULL
#define SHARED_REGION_NESTING_MAX_PPC64		0x0000000010000000ULL

#define SHARED_REGION_BASE_ARM			0x30000000ULL
#define SHARED_REGION_SIZE_ARM			0x10000000ULL
#define SHARED_REGION_NESTING_BASE_ARM		0x30000000ULL
#define SHARED_REGION_NESTING_SIZE_ARM		0x08000000ULL
#define SHARED_REGION_NESTING_MIN_ARM		?
#define SHARED_REGION_NESTING_MAX_ARM		?

#if defined(__i386__)
#define SHARED_REGION_BASE			SHARED_REGION_BASE_I386
#define SHARED_REGION_SIZE			SHARED_REGION_SIZE_I386
#define SHARED_REGION_NESTING_BASE		SHARED_REGION_NESTING_BASE_I386
#define SHARED_REGION_NESTING_SIZE		SHARED_REGION_NESTING_SIZE_I386
#define SHARED_REGION_NESTING_MIN		SHARED_REGION_NESTING_MIN_I386
#define SHARED_REGION_NESTING_MAX		SHARED_REGION_NESTING_MAX_I386
#elif defined(__x86_64__)
#define SHARED_REGION_BASE			SHARED_REGION_BASE_X86_64
#define SHARED_REGION_SIZE			SHARED_REGION_SIZE_X86_64
#define SHARED_REGION_NESTING_BASE		SHARED_REGION_NESTING_BASE_X86_64
#define SHARED_REGION_NESTING_SIZE		SHARED_REGION_NESTING_SIZE_X86_64
#define SHARED_REGION_NESTING_MIN		SHARED_REGION_NESTING_MIN_X86_64
#define SHARED_REGION_NESTING_MAX		SHARED_REGION_NESTING_MAX_X86_64
#elif defined(__ppc__)
#define SHARED_REGION_BASE			SHARED_REGION_BASE_PPC
#define SHARED_REGION_SIZE			SHARED_REGION_SIZE_PPC
#define SHARED_REGION_NESTING_BASE		SHARED_REGION_NESTING_BASE_PPC
#define SHARED_REGION_NESTING_SIZE		SHARED_REGION_NESTING_SIZE_PPC
#define SHARED_REGION_NESTING_MIN		SHARED_REGION_NESTING_MIN_PPC
#define SHARED_REGION_NESTING_MAX		SHARED_REGION_NESTING_MAX_PPC
#elif defined(__ppc64__)
#define SHARED_REGION_BASE			SHARED_REGION_BASE_PPC64
#define SHARED_REGION_SIZE			SHARED_REGION_SIZE_PPC64
#define SHARED_REGION_NESTING_BASE		SHARED_REGION_NESTING_BASE_PPC64
#define SHARED_REGION_NESTING_SIZE		SHARED_REGION_NESTING_SIZE_PPC64
#define SHARED_REGION_NESTING_MIN		SHARED_REGION_NESTING_MIN_PPC64
#define SHARED_REGION_NESTING_MAX		SHARED_REGION_NESTING_MAX_PPC64
#elif defined(__arm__)
#define SHARED_REGION_BASE			SHARED_REGION_BASE_ARM
#define SHARED_REGION_SIZE			SHARED_REGION_SIZE_ARM
#define SHARED_REGION_NESTING_BASE		SHARED_REGION_NESTING_BASE_ARM
#define SHARED_REGION_NESTING_SIZE		SHARED_REGION_NESTING_SIZE_ARM
#define SHARED_REGION_NESTING_MIN		SHARED_REGION_NESTING_MIN_ARM
#define SHARED_REGION_NESTING_MAX		SHARED_REGION_NESTING_MAX_ARM
#endif
```