### PR TITLE
Force and check `sig`

### DIFF
--- a/R/kill-tree.R
+++ b/R/kill-tree.R
@@ -139,6 +139,7 @@ ps_find_tree <- function(marker) {
 ps_kill_tree <- function(marker, sig = signals()$SIGKILL) {
 
   assert_string(marker)
+  assert_integer(sig)
 
   after <- as.numeric(strsplit(marker, "_", fixed = TRUE)[[1]][2])
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -113,6 +113,12 @@ assert_string <- function(x) {
                             " is not a string (character scalar)"))
 }
 
+assert_integer <- function(x) {
+  if (is.integer(x) && length(x) == 1 && !is.na(x)) return()
+  stop(ps__invalid_argument(match.call()$x,
+                            " is not a scalar integer"))
+}
+
 assert_character <- function(x) {
   if (is.character(x)) return()
   stop(ps__invalid_argument(match.call()$x,


### PR DESCRIPTION
Need to force before evaluation within `tryCatch()` to avoid cascading "restarting interrupted promise" errors when `sig` is passed a failing argument (like `tools$SIGTERM` instead of `tools::SIGTERM`).