### PR TITLE
Fix ps__system_cpu_times_linux to use clock_ticks

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # ps (development version)
 
+* `ps_system_cpu_times()` now returns CPU times divided by the HZ as reported by CLK_TCK, in-line with other OS's and the per-process version. (#144, @michaelwalshe).
+
 # ps 1.7.5
 
 No user visible changes.

--- a/R/linux.R
+++ b/R/linux.R
@@ -180,7 +180,7 @@ ps_cpu_count_physical_linux <- function() {
 ps__system_cpu_times_linux <- function() {
   tryCatch(
     clock_ticks <- as.numeric(system("getconf CLK_TCK", intern=TRUE)),
-    error = function(e) return(100)
+    error = function(e) return(250)
   )
   stat <- readLines("/proc/stat", n = 1)
   tms <- as.double(strsplit(stat, "\\s+")[[1]][-1]) / clock_ticks

--- a/R/linux.R
+++ b/R/linux.R
@@ -178,8 +178,12 @@ ps_cpu_count_physical_linux <- function() {
 }
 
 ps__system_cpu_times_linux <- function() {
+  tryCatch(
+    clock_ticks <- as.numeric(system("getconf CLK_TCK", intern=TRUE)),
+    error = function(e) return(100)
+  )
   stat <- readLines("/proc/stat", n = 1)
-  tms <- as.double(strsplit(stat, "\\s+")[[1]][-1])
+  tms <- as.double(strsplit(stat, "\\s+")[[1]][-1]) / clock_ticks
   nms <- c(
     "user", "nice", "system", "idle", "iowait", "irq", "softirq", "steal",
     "guest", "guest_nice"

--- a/R/linux.R
+++ b/R/linux.R
@@ -178,8 +178,8 @@ ps_cpu_count_physical_linux <- function() {
 }
 
 ps__system_cpu_times_linux <- function() {
-  tryCatch(
-    clock_ticks <- as.numeric(system("getconf CLK_TCK", intern=TRUE)),
+  clock_ticks <- tryCatch(
+    as.numeric(system("getconf CLK_TCK", intern=TRUE)),
     error = function(e) return(250)
   )
   stat <- readLines("/proc/stat", n = 1)


### PR DESCRIPTION
ps__system_cpu_times_linux wasn't dividing the CPU times by the HZ, and so was giving inaccurate CPU times.

Updated to get the value of CLK_TCK from getconf and divide. If this errors, uses the default value of 250 as stated in `man 7 time`:

<details>

```
   The software clock, HZ, and jiffies
       The accuracy of various system calls that set timeouts, (e.g., select(2), sigtimedwait(2)) and measure  CPU  time
       (e.g.,  getrusage(2))  is limited by the resolution of the software clock, a clock maintained by the kernel which
       measures time in jiffies.  The size of a jiffy is determined by the value of the kernel constant HZ.

       The value of HZ varies across kernel versions and hardware platforms.  On i386 the situation is  as  follows:  on
       kernels  up to and including 2.4.x, HZ was 100, giving a jiffy value of 0.01 seconds; starting with 2.6.0, HZ was
       raised to 1000, giving a jiffy of 0.001 seconds.  Since kernel 2.6.13, the HZ value is a kernel configuration pa‐
       rameter  and  can  be  100, 250 (the default) or 1000, yielding a jiffies value of, respectively, 0.01, 0.004, or
       0.001 seconds.  Since kernel 2.6.20, a further frequency is available: 300, a number that divides evenly for  the
       common video frame rates (PAL, 25 HZ; NTSC, 30 HZ).

       The  times(2)  system call is a special case.  It reports times with a granularity defined by the kernel constant
       USER_HZ.  User-space applications can determine the value of this constant using sysconf(_SC_CLK_TCK).
```

</details>


Per process CPU times did not need changing, as the C implementation multiplies the results from `/proc/stat` by `1 / sysconf(_SC_CLK_TCK)`.


Implementation details inspired by/checked against psutil here: https://github.com/giampaolo/psutil/blob/master/psutil/_pslinux.py#L584

Closes #144 