### PR TITLE
ps_name() fix for when ps_cmdline() returns an empty vector

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # ps (development version)
 
+* `ps_name()` now does not fail in the rare case when `ps_cmdline()` returns an empty vector (#150).
+
 * `ps_system_cpu_times()` now returns CPU times divided by the HZ as reported by CLK_TCK, in-line with other OS's and the per-process version. (#144, @michaelwalshe).
 
 # ps 1.7.5

--- a/R/low-level.R
+++ b/R/low-level.R
@@ -153,7 +153,7 @@ ps_parent <- function(p = ps_handle()) {
 #'
 #' The name of the program, which is typically the name of the executable.
 #'
-#' On on Unix this can change, e.g. via an exec*() system call.
+#' On Unix this can change, e.g. via an exec*() system call.
 #'
 #' `ps_name()` works on zombie processes.
 #'
@@ -181,7 +181,7 @@ ps_name <- function(p = ps_handle()) {
       ps_cmdline(p),
       error = function(e) NULL
     )
-    if (!is.null(cmdline)) {
+    if (!is.null(cmdline) && length(cmdline) > 0L) {
       exname <- basename(cmdline[1])
       if (str_starts_with(exname, n)) n <- exname
     }

--- a/man/ps_name.Rd
+++ b/man/ps_name.Rd
@@ -16,7 +16,7 @@ Character scalar.
 The name of the program, which is typically the name of the executable.
 }
 \details{
-On on Unix this can change, e.g. via an exec*() system call.
+On Unix this can change, e.g. via an exec*() system call.
 
 \code{ps_name()} works on zombie processes.
 }


### PR DESCRIPTION
Fix for issue [#150](https://github.com/r-lib/ps/issues/150).
