### PR TITLE
Add Emscripten system detection in `configure` script

### DIFF
--- a/configure
+++ b/configure
@@ -24,6 +24,10 @@ else
     UNAME=Windows
 fi
 
+if [ -n "$EMSCRIPTEN" ] && [ -n "$CROSS_COMPILE" ]; then
+    UNAME=Emscripten
+fi
+
 unset WINDOWS
 if [ "$R_OSTYPE" = "windows" ]; then WINDOWS=true; fi
 


### PR DESCRIPTION
This change adds detection for cross-compiling using Emscripten in the `configure` script, allowing the `ps` package to be built for Emscripten/webR.

The package itself does not make much sense under Wasm: there is just one process, no forking, and no POSIX signals. However, `ps` handles unsupported platforms reasonably by throwing a "Not implemented for this platform" error, and it is useful to have the package available for other packages that list it as a dependency.