### PR TITLE
Changed named list for named vector in low_level.R Fixed #160

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,4 +33,4 @@ Config/Needs/website: tidyverse/tidytemplate
 Config/testthat/edition: 3
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.2

--- a/R/low-level.R
+++ b/R/low-level.R
@@ -492,7 +492,7 @@ ps_cpu_times <- function(p = ps_handle()) {
 #'
 #' `ps_memory_info()` returns information about memory usage.
 #'
-#' It returns a named list. Portable fields:
+#' It returns a named vector. Portable fields:
 #' * `rss`: "Resident Set Size", this is the non-swapped physical memory a
 #'   process has used (bytes). On UNIX it matches "top"‘s 'RES' column (see doc). On
 #'   Windows this is an alias for `wset` field and it matches "Memory"

--- a/man/ps-package.Rd
+++ b/man/ps-package.Rd
@@ -3,7 +3,6 @@
 \docType{package}
 \name{ps-package}
 \alias{ps-package}
-\alias{_PACKAGE}
 \title{ps: List, Query, Manipulate System Processes}
 \description{
 List, query and manipulate all system processes, on 'Windows', 'Linux' and 'macOS'.

--- a/man/ps_memory_info.Rd
+++ b/man/ps_memory_info.Rd
@@ -21,7 +21,7 @@ Memory usage information
 \details{
 \code{ps_memory_info()} returns information about memory usage.
 
-It returns a named list. Portable fields:
+It returns a named vector. Portable fields:
 \itemize{
 \item \code{rss}: "Resident Set Size", this is the non-swapped physical memory a
 process has used (bytes). On UNIX it matches "top"‘s 'RES' column (see doc). On

--- a/ps.Rproj
+++ b/ps.Rproj
@@ -16,4 +16,5 @@ StripTrailingWhitespace: Yes
 
 BuildType: Package
 PackageUseDevtools: Yes
+PackageCleanBeforeInstall: Yes
 PackageInstallArgs: --no-multiarch --with-keep.source

--- a/ps.Rproj
+++ b/ps.Rproj
@@ -16,5 +16,4 @@ StripTrailingWhitespace: Yes
 
 BuildType: Package
 PackageUseDevtools: Yes
-PackageCleanBeforeInstall: Yes
 PackageInstallArgs: --no-multiarch --with-keep.source


### PR DESCRIPTION
Changed "It returns a named list" for "It returns a named vector" in the low_level.R file, ps_memory_info() function's doc. Fixed #160.