### PR TITLE
add -lpthread on windows

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -29,7 +29,11 @@ jobs:
           - {os: macos-latest,   r: 'devel'}
           - {os: macos-latest,   r: 'release'}
 
+          - {os: windows-latest, r: 'devel'}
           - {os: windows-latest, r: 'release'}
+          - {os: windows-latest, r: 'oldrel-1'}
+          - {os: windows-latest, r: 'oldrel-2'}
+          - {os: windows-latest, r: 'oldrel-3'}
           # use 4.0 or 4.1 to check with rtools40's older compiler
           - {os: windows-latest, r: 'oldrel-4'}
           - {os: windows-latest, r: '3.6.3'}

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -29,11 +29,7 @@ jobs:
           - {os: macos-latest,   r: 'devel'}
           - {os: macos-latest,   r: 'release'}
 
-          - {os: windows-latest, r: 'devel'}
           - {os: windows-latest, r: 'release'}
-          - {os: windows-latest, r: 'oldrel-1'}
-          - {os: windows-latest, r: 'oldrel-2'}
-          - {os: windows-latest, r: 'oldrel-3'}
           # use 4.0 or 4.1 to check with rtools40's older compiler
           - {os: windows-latest, r: 'oldrel-4'}
           - {os: windows-latest, r: '3.6.3'}

--- a/configure
+++ b/configure
@@ -97,7 +97,7 @@ if [ -n "$WINDOWS" ]; then
     OBJECTS="${OBJECTS} arch/windows/wmi.o"
 
     LIBRARIES="psapi kernel32 advapi32 shell32 netapi32 iphlpapi wtsapi32"
-    LIBRARIES="${LIBRARIES} ws2_32 PowrProf Pdh"
+    LIBRARIES="${LIBRARIES} ws2_32 PowrProf Pdh pthread"
 
     TARGETS=interrupt
 


### PR DESCRIPTION
Version 1.8.0 failed to build on conda-forge on Windows; the error was 
```
undefined reference to `clock_gettime'
```

Adding pthread to the list of libraries in Windows resolves the issue.

I'm assuming this for some reason isn't necessary in the standard CRAN build process, since otherwise it would have been caught already.