### PR TITLE
Do not include libgen.h on Linux, to fix Alpine 3.19

### DIFF
--- a/src/api-linux.c
+++ b/src/api-linux.c
@@ -18,7 +18,9 @@
 #include <sys/sysinfo.h>
 #include <sched.h>
 #include <sys/vfs.h>
+#ifndef __linux__
 #include <libgen.h>
+#endif
 #include <sys/syscall.h>
 #include <sys/epoll.h>
 #include <time.h>

--- a/src/api-posix.c
+++ b/src/api-posix.c
@@ -16,7 +16,11 @@
 #include <sys/sysmacros.h>
 #endif
 #include <sys/param.h>
+#ifdef __linux__
+char *dirname(char *path);
+#else
 #include <libgen.h>
+#endif
 #include <stdlib.h>
 
 #include "ps-internal.h"


### PR DESCRIPTION
Alpine 3.19 libgen.h and string.h have conflicting declaration of `basename()`
